### PR TITLE
Making instance indices in instance table contigous after filtering for a subset

### DIFF
--- a/src/lm_pub_quiz/data/dataset.py
+++ b/src/lm_pub_quiz/data/dataset.py
@@ -153,7 +153,7 @@ class Relation(RelationBase):
         self, indices: Sequence[int], *, save_path: Optional[PathLike], keep_answer_space: bool = False
     ) -> Self:
         original_instance_table = self.instance_table
-        instance_table = original_instance_table.iloc[indices].copy()
+        instance_table = original_instance_table.iloc[indices].copy().reset_index()
 
         if keep_answer_space and self._answer_space is not None:
             answer_space = self._answer_space

--- a/src/lm_pub_quiz/data/results.py
+++ b/src/lm_pub_quiz/data/results.py
@@ -262,7 +262,7 @@ class RelationResult(RelationBase):
         original_instance_table = self.instance_table
         original_answer_space = self.answer_space
 
-        instance_table = original_instance_table.iloc[indices].copy()
+        instance_table = original_instance_table.iloc[indices].copy().reset_index()
 
         metadata = self.metadata.copy()
         if dataset_name is not None:

--- a/tests/test_dataset_representation.py
+++ b/tests/test_dataset_representation.py
@@ -73,4 +73,7 @@ def test_dataset_subset_filtering(request):
     assert len(subset[0]) == 2
     assert len(subset[1]) == 4
 
+    assert tuple(subset[0].instance_table.index.values) == tuple(range(2))
+    assert tuple(subset[1].instance_table.index.values) == tuple(range(4))
+
     assert list(subset[1].answer_space) == ["the lion", "the kid", "the caterpillar"]

--- a/tests/test_result_representation.py
+++ b/tests/test_result_representation.py
@@ -238,6 +238,9 @@ def test_result_subset_smaller_answer_space(request, tmp_path, lazy_result):
 
     subset = results.filter_subset(indices, save_path=tmp_path if lazy_result else None)
 
+    assert tuple(subset[0].instance_table.index.values) == tuple(range(2))
+    assert tuple(subset[1].instance_table.index.values) == tuple(range(4))
+
     r: RelationResult
     for r in subset:
         assert isinstance(r, RelationResult)


### PR DESCRIPTION
I would expect the indices to be contiguous after having filtered a dataset for a subset. At the moment, this is not the cases. Instead, the index of the pandas DataFrame still shows the old indices.

Furthermore, the behaviors is inconsistent if we do not implement it this way: If the dataset is saved, the original indices are not stored and hence during loading a new (contiguous) index is created. When not storing the dataset/results in-between, the behavior should still be the same.