### PR TITLE
Additional result features

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ detached = true
 dependencies = [
   "black>=24.1.0",
   "mypy>=1.8.0",
-  "ruff>=0.3",
+  "ruff>=0.4",
 ]
 [tool.hatch.envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {args:src/lm_pub_quiz tests}"

--- a/src/lm_pub_quiz/data/base.py
+++ b/src/lm_pub_quiz/data/base.py
@@ -481,6 +481,12 @@ class DatasetBase(DataBase, Generic[RT]):
             msg = f"Relation {key} not found in this {self.__class__.__name__}."
             raise KeyError(msg)
 
+    def __contains__(self, key: str) -> bool:
+        for relation in self:
+            if relation.relation_code == key:
+                return True
+        return False
+
     def __iter__(self) -> Iterator[RT]:
         yield from self.relation_data
 

--- a/src/lm_pub_quiz/data/base.py
+++ b/src/lm_pub_quiz/data/base.py
@@ -277,6 +277,9 @@ class RelationBase(DataBase):
             msg = f"Format .{'.'.join(fmt)} not recognized: Could not load instances at {path}."
             raise ValueError(msg)
 
+        if instance_table.index.name is None:
+            instance_table.index.name = "instance"
+
         return instance_table
 
     @classmethod

--- a/src/lm_pub_quiz/data/base.py
+++ b/src/lm_pub_quiz/data/base.py
@@ -155,13 +155,10 @@ class RelationBase(DataBase):
             return "single instance per answer"
 
     @overload
-    def relation_info(self, /) -> Dict[str, Any]: ...
+    def relation_info(self, /, **kw) -> Dict[str, Any]: ...
 
     @overload
     def relation_info(self, key: str, /) -> Any: ...
-
-    @overload
-    def relation_info(self, /, **kw) -> None: ...
 
     def relation_info(self, key: Optional[str] = None, /, **kw) -> Union[None, Any, Dict[str, Any]]:
         """Get or set additional relation information."""
@@ -172,11 +169,11 @@ class RelationBase(DataBase):
                 return self._relation_info[key]
         elif len(kw) > 0:
             self._relation_info.update(kw)
-        else:
-            info = self._relation_info.copy()
-            if "cardinality" not in info:
-                info["cardinality"] = self._derived_cardinality
-            return info
+
+        info = self._relation_info.copy()
+        if "cardinality" not in info:
+            info["cardinality"] = self._derived_cardinality
+        return info
 
     @staticmethod
     def _generate_obj_ids(n: int, *, id_prefix: str = ""):

--- a/src/lm_pub_quiz/data/base.py
+++ b/src/lm_pub_quiz/data/base.py
@@ -506,3 +506,6 @@ class DatasetBase(DataBase, Generic[RT]):
     def save(self, path: PathLike, fmt: InstanceTableFileFormat = None) -> None:
         for result in self:
             result.save(path, fmt=fmt)
+
+    def joined_instance_table(self) -> pd.DataFrame:
+        return pd.concat({relation.relation_code: relation.instance_table for relation in self}, names=["relation"])

--- a/src/lm_pub_quiz/data/dataset.py
+++ b/src/lm_pub_quiz/data/dataset.py
@@ -254,7 +254,13 @@ class Dataset(DatasetBase[Relation]):
 
     @classmethod
     def from_path(
-        cls, path: PathLike, *, lazy: bool = True, fmt: InstanceTableFileFormat = None, **kwargs
+        cls,
+        path: PathLike,
+        *,
+        lazy: bool = True,
+        fmt: InstanceTableFileFormat = None,
+        relation_info: Optional[PathLike] = None,
+        **kwargs,
     ) -> "Dataset":
         """
         Loads a multiple choice dataset from a specified directory path.
@@ -294,11 +300,24 @@ class Dataset(DatasetBase[Relation]):
 
         log.info("Loaded dataset `%s` (%d relations) from `%s`.", kwargs["name"], len(relation_files), dataset_path)
 
-        return cls(relations, **kwargs)
+        obj = cls(relations, **kwargs)
+
+        if relation_info is not None:
+            with open(relation_info) as f:
+                obj.update_relation_info(json.load(f))
+
+        return obj
 
     @classmethod
     def from_name(
-        cls, name: str, *, lazy: bool = True, base_path: Optional[Path] = None, chunk_size: int = 10 * 1024, **kwargs
+        cls,
+        name: str,
+        *,
+        lazy: bool = True,
+        base_path: Optional[Path] = None,
+        chunk_size: int = 10 * 1024,
+        relation_info: Optional[PathLike] = None,
+        **kwargs,
     ) -> "Dataset":
         """
         Loads a dataset from the cache (if available) or the url which is specified in the internal dataset table.
@@ -357,7 +376,7 @@ class Dataset(DatasetBase[Relation]):
         else:
             log.debug("Dataset %s found in cache at %s.", name, dataset_path)
 
-        return cls.from_path(dataset_path, lazy=lazy, name=name, **kwargs)
+        return cls.from_path(dataset_path, lazy=lazy, name=name, relation_info=relation_info, **kwargs)
 
     def activated(self):
         if not self.is_lazy:

--- a/src/lm_pub_quiz/data/dataset.py
+++ b/src/lm_pub_quiz/data/dataset.py
@@ -57,13 +57,18 @@ class Relation(RelationBase):
         answer_space: Optional[pd.Series],
         instance_table: Optional[pd.DataFrame],
         lazy_options: Optional[Dict[str, Any]],
+        relation_info: Optional[Dict[str, Any]] = None,
     ):
         if instance_table is None and lazy_options is None:
             msg = "Either instance_table of lazy_options must be specified"
             raise ValueError(msg)
 
         super().__init__(
-            relation_code, instance_table=instance_table, answer_space=answer_space, lazy_options=lazy_options
+            relation_code,
+            instance_table=instance_table,
+            answer_space=answer_space,
+            lazy_options=lazy_options,
+            relation_info=relation_info,
         )
         self.templates = templates
 

--- a/src/lm_pub_quiz/data/results.py
+++ b/src/lm_pub_quiz/data/results.py
@@ -126,7 +126,7 @@ class RelationResult(RelationBase):
                             "Metadata file exists, but no metadata for given result with relation code %s found.",
                             relation_code,
                         )
-                    raise
+                        raise
             else:
                 metadata = {}
 

--- a/src/lm_pub_quiz/data/results.py
+++ b/src/lm_pub_quiz/data/results.py
@@ -423,7 +423,13 @@ class DatasetResults(DatasetBase[RelationResult]):
 
     @classmethod
     def from_path(
-        cls, path: PathLike, *, lazy: bool = True, fmt: InstanceTableFileFormat = None, **kwargs
+        cls,
+        path: PathLike,
+        *,
+        lazy: bool = True,
+        fmt: InstanceTableFileFormat = None,
+        relation_info: Optional[PathLike] = None,
+        **kwargs,
     ) -> "DatasetResults":
         """
         Loads a results from a specified directory path.
@@ -478,6 +484,11 @@ class DatasetResults(DatasetBase[RelationResult]):
                     lazy=lazy,
                 )
             )
+
+        if relation_info is not None:
+            with open(relation_info) as f:
+                obj.update_relation_info(json.load(f))
+
         return obj
 
     def activated(self) -> Self:

--- a/src/lm_pub_quiz/data/results.py
+++ b/src/lm_pub_quiz/data/results.py
@@ -504,7 +504,7 @@ class DatasetResults(DatasetBase[RelationResult]):
         *,
         accumulate: Union[bool, None, str] = False,
         explode: bool = False,
-        divide_support: bool = False,
+        divide_support: bool = True,
     ) -> Union[pd.DataFrame, pd.Series]:
         """Return the metrics for the relations in this dataset.
 
@@ -513,7 +513,8 @@ class DatasetResults(DatasetBase[RelationResult]):
                 compute the overall scores for the complete dataset by setting `accumulate=True`.
             explode (bool): Set to true if relations not only have a single group but multiple.
             divide_support (bool): Set to true to divide the support (added by a relation to a group) by the number of
-                groups it adds to: This leads to a dataframe where the weightted mean is equal to the overall score.
+                groups it adds to (only relevant if there are multiple groups per relation i.e. when `explode` is set).
+                This leads to a dataframe where the weightted mean is equal to the overall score.
 
         Returns:
             pandas.DataFrame | pandas.Series: A Series or DataFrame with the selected metrics depending on whether all
@@ -522,10 +523,6 @@ class DatasetResults(DatasetBase[RelationResult]):
         """
         if not isinstance(accumulate, str) and explode:
             msg = "`explode` can only be used if a relation information field is passed to accumulate relation scores."
-            raise ValueError(msg)
-
-        if divide_support and not explode:
-            msg = "`divide_support` can only be applied if `explode` is used."
             raise ValueError(msg)
 
         if isinstance(metrics, str):

--- a/src/lm_pub_quiz/evaluator.py
+++ b/src/lm_pub_quiz/evaluator.py
@@ -483,7 +483,7 @@ class Evaluator(BaseEvaluator):
             model_type = cls._infer_type_from_name(model_str)
             log.debug("Inferred type of model `%s`: %s", model_str, model_type)
 
-        evaluator_class: Type["Evaluator"]
+        evaluator_class: Type[Evaluator]
         if model_type == "MLM":
             evaluator_class = MaskedLMEvaluator
         elif model_type == "CLM":

--- a/src/lm_pub_quiz/evaluator.py
+++ b/src/lm_pub_quiz/evaluator.py
@@ -136,7 +136,6 @@ class BaseEvaluator(ABC):
             desc=f"Relation {relation.relation_code}",
         ):
             row = r.to_dict()
-            row["answer_idx"] = relation.answer_space.index.get_loc(row["obj_id"])
 
             pll_scores = self.evaluate_instance(
                 template=template,

--- a/src/lm_pub_quiz/metrics/__init__.py
+++ b/src/lm_pub_quiz/metrics/__init__.py
@@ -1,6 +1,7 @@
 from lm_pub_quiz.metrics.base import RelationMetric
 from lm_pub_quiz.metrics.basic import Accuracy, PrecisionAtK
 from lm_pub_quiz.metrics.confidence import ConfidenceMargin, ConfidenceScore, SoftmaxBase, UncertaintyScore
+from lm_pub_quiz.metrics.util import accumulate_metrics
 
 __all__ = [
     "RelationMetric",
@@ -10,4 +11,5 @@ __all__ = [
     "ConfidenceMargin",
     "ConfidenceScore",
     "UncertaintyScore",
+    "accumulate_metrics",
 ]

--- a/src/lm_pub_quiz/metrics/basic.py
+++ b/src/lm_pub_quiz/metrics/basic.py
@@ -8,16 +8,16 @@ from lm_pub_quiz.util import sort_scores
 
 
 class BasicMetric(RelationMetric):
-    metric_name = "num_instances"
+    metric_name = "support"
 
     def reset(self):
-        self.num_instances = 0
+        self.support = 0
 
     def add_instance(self, row: Mapping):  # noqa: ARG002
-        self.num_instances += 1
+        self.support += 1
 
     def compute(self):
-        return {"num_instances": self.num_instances}
+        return {"support": self.support}
 
 
 class PrecisionAtK(BasicMetric):
@@ -52,7 +52,7 @@ class PrecisionAtK(BasicMetric):
         if self.num_correct_at_k is None:
             return super().compute()
         else:
-            return {**super().compute(), "precision_at_k": (self.num_correct_at_k / self.num_instances).tolist()}
+            return {**super().compute(), "precision_at_k": (self.num_correct_at_k / self.support).tolist()}
 
 
 class Accuracy(BasicMetric):
@@ -68,4 +68,4 @@ class Accuracy(BasicMetric):
             self.num_correct += 1
 
     def compute(self) -> Dict[str, Any]:
-        return {**super().compute(), "accuracy": self.num_correct / self.num_instances}
+        return {**super().compute(), "accuracy": self.num_correct / self.support}

--- a/src/lm_pub_quiz/metrics/util.py
+++ b/src/lm_pub_quiz/metrics/util.py
@@ -4,8 +4,5 @@ import pandas as pd
 
 def accumulate_metrics(group: pd.DataFrame):
     return pd.Series(
-        {
-            k: (np.average(v, weights=group["num_instances"]) if k != "num_instances" else v.sum())
-            for k, v in group.items()
-        }
+        {k: (np.average(v, weights=group["support"]) if k != "support" else v.sum()) for k, v in group.items()}
     )

--- a/src/lm_pub_quiz/metrics/util.py
+++ b/src/lm_pub_quiz/metrics/util.py
@@ -1,0 +1,11 @@
+import numpy as np
+import pandas as pd
+
+
+def accumulate_metrics(group: pd.DataFrame):
+    return pd.Series(
+        {
+            k: (np.average(v, weights=group["num_instances"]) if k != "num_instances" else v.sum())
+            for k, v in group.items()
+        }
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,8 +11,8 @@ log = logging.getLogger(__name__)
 def test_help_texts():
     """Check the help text is ok, and the commands are available."""
     for script in ("evaluate_model", "rank_answers", "score_sentence"):
-        result = subprocess.run(
-            [str(script), "--help"], check=True, capture_output=True  # noqa: S603 (we can trust the script names)
+        result = subprocess.run(  # noqa: S603 (we can trust the script names)
+            [str(script), "--help"], check=True, capture_output=True
         )
         stdout = result.stdout.decode("utf8")
 

--- a/tests/test_data/dummy_relation_info.json
+++ b/tests/test_data/dummy_relation_info.json
@@ -1,0 +1,8 @@
+{
+  "example_1": {
+    "domain": ["a", "b", "c"]
+  },
+  "example_2": {
+    "domain": ["b", "d"]
+  }
+}

--- a/tests/test_data/new_style_results_with_mistakes/example_1_results.jsonl
+++ b/tests/test_data/new_style_results_with_mistakes/example_1_results.jsonl
@@ -1,0 +1,3 @@
+{"sub_id":"xyz","sub_label":"the traveler","answer_idx":0,"pll_scores":[-39.4665284157,-41.3839921951,-40.8367753029]}
+{"sub_id":"abc","sub_label":"the sports team","answer_idx":1,"pll_scores":[-43.2029886246,-38.8553466797,-52.4907488823]}
+{"sub_id":"pou","sub_label":"the surgeon","answer_idx":2,"pll_scores":[-37.6923413277,-42.2200908661,-31.9606842995]}

--- a/tests/test_data/new_style_results_with_mistakes/example_2_results.jsonl
+++ b/tests/test_data/new_style_results_with_mistakes/example_2_results.jsonl
@@ -1,0 +1,6 @@
+{"sub_label":"meat","sub_id":"biq","answer_idx":0,"pll_scores":[-18.1812758446,-17.5053930283,-15.8877744675]}
+{"sub_label":"a bone","sub_id":"myn","answer_idx":0,"pll_scores":[-29.4390444756,-27.9115614891,-27.5443906784]}
+{"sub_label":"candy","sub_id":"ejy","answer_idx":1,"pll_scores":[-19.3051533699,-19.7057299614,-24.0674858093]}
+{"sub_label":"a green apple","sub_id":"sgq","answer_idx":1,"pll_scores":[-19.5387759209,-19.5001821518,-23.1424221992]}
+{"sub_label":"a leaf","sub_id":"jpl","answer_idx":2,"pll_scores":[-25.6837468147,-27.8830237389,-19.3651065826]}
+{"sub_label":"a plant","sub_id":"pmz","answer_idx":2,"pll_scores":[-21.2618765831,-26.721777916,-17.3190736771]}

--- a/tests/test_data/new_style_results_with_mistakes/metadata_results.json
+++ b/tests/test_data/new_style_results_with_mistakes/metadata_results.json
@@ -1,0 +1,52 @@
+{
+    "example_1": {
+        "templates": [
+            "[X] lost [Y]."
+        ],
+        "template_index": 0,
+        "model_name_or_path": "distilbert-base-cased",
+        "num_original_instances": 3,
+        "subsampled": null,
+        "time_start": "2024-03-04 17:28:55",
+        "answer_space_ids": [
+            "zyx",
+            "cba",
+            "uop"
+        ],
+        "answer_space_labels": [
+            "the souvenir",
+            "the football",
+            "the scalpel"
+        ],
+        "metrics": {},
+        "time_end": "2024-03-04 17:28:56",
+        "reduction": "sum",
+        "dataset_path": "tests/test_data/dummy_dataset",
+        "dataset_name": "dummy_dataset"
+    },
+    "example_2": {
+        "templates": [
+            "[Y] eats [X]."
+        ],
+        "template_index": 0,
+        "model_name_or_path": "distilbert-base-cased",
+        "num_original_instances": 6,
+        "subsampled": null,
+        "time_start": "2024-03-04 17:28:56",
+        "answer_space_ids": [
+            "dtz",
+            "irw",
+            "zte"
+        ],
+        "answer_space_labels": [
+            "the lion",
+            "the kid",
+            "the caterpillar"
+        ],
+        "metrics": {},
+        "time_end": "2024-03-04 17:28:57",
+        "reduction": "sum",
+        "dataset_path": "tests/test_data/dummy_dataset",
+        "dataset_name": "dummy_dataset"
+    }
+}

--- a/tests/test_dataset_representation.py
+++ b/tests/test_dataset_representation.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 
 from lm_pub_quiz import Dataset, Relation
 
@@ -23,6 +24,15 @@ def test_loading_dataset(request):
 
     assert len(dataset) == 2
     assert str(dataset) == "Dataset(dummy_dataset: example_1, example_2)"
+
+    assert "example_1" in dataset
+    assert "example_2" in dataset
+    assert "example_3" not in dataset
+
+    assert dataset["example_1"].relation_code == "example_1"
+
+    with pytest.raises(KeyError):
+        _ = dataset["example_3"]
 
 
 def test_lazy_dataset_loading(request):

--- a/tests/test_dataset_representation.py
+++ b/tests/test_dataset_representation.py
@@ -15,7 +15,7 @@ def test_relation_loading(request):
     assert len(relation.instance_table) == 6
     assert len(relation.subsample(4)) == 4
 
-    assert relation.instance_table.index.name == "instance"
+    assert relation.instance_table.index.names == ["instance"]
 
 
 def test_loading_dataset(request):

--- a/tests/test_dataset_representation.py
+++ b/tests/test_dataset_representation.py
@@ -15,6 +15,8 @@ def test_relation_loading(request):
     assert len(relation.instance_table) == 6
     assert len(relation.subsample(4)) == 4
 
+    assert relation.instance_table.index.name == "instance"
+
 
 def test_loading_dataset(request):
     dataset: Dataset = Dataset.from_path(request.path.parent / "test_data" / "dummy_dataset")

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -181,7 +181,7 @@ def test_dataset_evaluation_with_direct_scores(distilbert, request, tmp_path):
             assert r.metadata["reduction"] == "sum"
             assert "distilbert" in r.metadata["model_name_or_path"]
 
-    assert results.get_metrics(["accuracy"], accumulate_all=True)["accuracy"] >= 0.5
+    assert results.get_metrics(["accuracy"], accumulate=True)["accuracy"] >= 0.5
 
 
 def test_dataset_evaluation_with_save_path(distilbert, request, tmp_path):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -35,12 +35,12 @@ def test_result_accumulation_with_relation_info(request):
     assert df.loc["b", "support"] == 6.0
 
 
-def test_results_with_multiple_tags(request):
+def test_results_with_multiple_tags_without_dividied_support(request):
     results = DatasetResults.from_path(request.path.parent / "test_data" / "new_style_results_with_mistakes")
 
     results.update_relation_info({"example_1": {"domain": ("a", "b", "c")}, "example_2": {"domain": ("b", "d")}})
 
-    df = results.get_metrics(["accuracy"], accumulate="domain", explode=True)
+    df = results.get_metrics(["accuracy"], accumulate="domain", explode=True, divide_support=False)
 
     assert df.loc["a", "accuracy"] == 1.0
     assert df.loc["a", "support"] == 3
@@ -57,7 +57,7 @@ def test_results_with_multiple_tags_divided_support(request):
 
     results.update_relation_info({"example_1": {"domain": ("a", "b", "c")}, "example_2": {"domain": ("b", "d")}})
 
-    df = results.get_metrics(["accuracy"], accumulate="domain", explode=True, divide_support=True)
+    df = results.get_metrics(["accuracy"], accumulate="domain", explode=True)
 
     assert df.loc["a", "accuracy"] == 1.0
     assert df.loc["a", "support"] == 1.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,40 @@
+import logging
+
+from lm_pub_quiz import DatasetResults
+
+log = logging.getLogger(__name__)
+
+
+def test_result_accumulation(request):
+    """Test whether the deprecated representation of the results can still be loaded."""
+
+    results = DatasetResults.from_path(request.path.parent / "test_data" / "new_style_results_with_mistakes")
+
+    df = results.get_metrics(["accuracy"], accumulate=False)
+
+    # todo add an example where the accuracies are different
+
+    assert df.loc["example_1", "accuracy"] == 1.0
+    assert df.loc["example_2", "accuracy"] == 0.5
+
+    assert results.get_metrics(["accuracy"], accumulate=True)["accuracy"] == (1.0*3 + 0.5*6) / 9
+
+
+def test_result_accumulation_with_relation_info(request):
+    """Test whether the deprecated representation of the results can still be loaded."""
+
+    results = DatasetResults.from_path(request.path.parent / "test_data" / "new_style_results_with_mistakes")
+
+    results.update_relation_info({
+        "example_1": {"domain": "a"},
+        "example_2": {"domain": "b"}
+    })
+
+    df = results.get_metrics(["accuracy"], accumulate="domain")
+
+    assert df.loc["a", "accuracy"] == 1.0
+    assert df.loc["b", "accuracy"] == 0.5
+
+
+def test_restults_with_multiple_tags(request):
+    raise NotImplementedError()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -67,3 +67,22 @@ def test_results_with_multiple_tags_divided_support(request):
     assert df.loc["c", "support"] == 1
     assert df.loc["d", "accuracy"] == 0.5
     assert df.loc["d", "support"] == 3
+
+
+def test_result_accumulation_with_relation_info_from_path(request):
+    """Test whether the deprecated representation of the results can still be loaded."""
+
+    results = DatasetResults.from_path(
+        request.path.parent / "test_data" / "new_style_results_with_mistakes",
+        relation_info=request.path.parent / "test_data" / "dummy_relation_info.json",
+    )
+    df = results.get_metrics(["accuracy"], accumulate="domain", explode=True)
+
+    assert df.loc["a", "accuracy"] == 1.0
+    assert df.loc["a", "support"] == 1.0
+    assert df.loc["b", "accuracy"] == (1 * 1.0 + 0.5 * 3) / 4
+    assert df.loc["b", "support"] == 4
+    assert df.loc["c", "accuracy"] == 1.0
+    assert df.loc["c", "support"] == 1
+    assert df.loc["d", "accuracy"] == 0.5
+    assert df.loc["d", "support"] == 3

--- a/tests/test_result_representation.py
+++ b/tests/test_result_representation.py
@@ -328,3 +328,18 @@ def test_result_formats(request, tmp_path):
         ).all(axis=None)
 
         assert tuple(a.instance_table.loc[0, "tokens"]) == tuple(a.instance_table.loc[0, "tokens"])
+
+
+def test_joined_instance_table(request):
+    """Test whether the deprecated representation of the results can still be loaded."""
+
+    results = DatasetResults.from_path(request.path.parent / "test_data" / "new_style_results", lazy=True)
+
+    df = results.joined_instance_table()
+
+    assert len(df) == 9
+
+    assert df.index.names == ["relation", "instance"]
+
+    assert len(df.loc["example_1"]) == 3
+    assert len(df.loc["example_2"]) == 6


### PR DESCRIPTION
This PR improves interaction with dataset & result objects. In particular, it provides improved capabilities for accumulating relation scores based on predetermined relation types (e.g. domains). The annotation features enables the distribution of annotations independent of the dataset itself.


### Instance Table for the Complete Dataset

This feature allows the user to easily produce a DataFrame with all of the predictions for the entire dataset (instead of only one per relation):

```python
from lm_pub_quiz import DatasetResults

results = DatasetResults.from_path("tests/test_data/new_style_results")
print(results.joined_instance_table())
```
```
                   sub_id        sub_label  answer_idx                                        pll_scores obj_id        obj_label
relation  instance                                                                                                              
example_1 0           xyz     the traveler           0  [-39.4665284157, -41.3839921951, -40.8367753029]    zyx     the souvenir
          1           abc  the sports team           1  [-43.2029886246, -38.8553466797, -52.4907488823]    cba     the football
          2           pou      the surgeon           2  [-37.6923413277, -42.2200908661, -31.9606842995]    uop      the scalpel
example_2 0           biq             meat           0  [-12.1812758446, -17.5053930283, -15.8877744675]    dtz         the lion
          1           myn           a bone           0  [-23.4390444756, -27.9115614891, -27.5443906784]    dtz         the lion
          2           ejy            candy           1  [-19.3051533699, -15.7057299614, -24.0674858093]    irw          the kid
          3           sgq    a green apple           1  [-19.5387759209, -19.5001821518, -23.1424221992]    irw          the kid
          4           jpl           a leaf           2  [-25.6837468147, -27.8830237389, -19.3651065826]    zte  the caterpillar
          5           pmz          a plant           2   [-21.2618765831, -26.721777916, -17.3190736771]    zte  the caterpillar
```

### Accumulation based on Annotations
This feature enable (1) the annotation of relations with tags (e.g. domains) and (2) implements the accumulation of metrics based on these:

```python
results = DatasetResults.from_path("tests/test_data/new_style_results_with_mistakes")

results.update_relation_info({"example_1": {"domain": ("a", "b", "c")}, "example_2": {"domain": ("b", "d")}})

results.get_metrics(["accuracy"], accumulate="domain", explode=True)
```
```
        accuracy  support
domain                   
a       1.000000      3.0
b       0.666667      9.0
c       1.000000      3.0
d       0.500000      6.0
```

### Membership Test
This features allows the user to test whether a relation (i.e. a relation code) is part of the dataset:

```python
from lm_pub_quiz import Dataset

bear = Dataset.from_name("bear")

print("P6" in bear)  # True
print("P0" in bear)  # False
```