### PR TITLE
Enable Probing using Multiple Templates in One Call

### DIFF
--- a/tests/test_data/dummy_dataset_multiple_templates/example_1.jsonl
+++ b/tests/test_data/dummy_dataset_multiple_templates/example_1.jsonl
@@ -1,0 +1,3 @@
+{"sub_id": "xyz", "sub_label": "the traveler", "obj_id": "zyx", "obj_label": "the souvenir"}
+{"sub_id": "abc", "sub_label": "the sports team", "obj_id": "cba", "obj_label": "the football"}
+{"sub_id": "pou", "sub_label": "the surgeon", "obj_id": "uop", "obj_label": "the scalpel"}

--- a/tests/test_data/dummy_dataset_multiple_templates/example_2.jsonl
+++ b/tests/test_data/dummy_dataset_multiple_templates/example_2.jsonl
@@ -1,0 +1,6 @@
+{"sub_label": "meat", "obj_label": "the lion", "sub_id": "biq", "obj_id": "dtz"}
+{"sub_label": "a bone", "obj_label": "the lion", "sub_id": "myn", "obj_id": "dtz"}
+{"sub_label": "candy", "obj_label": "the kid", "sub_id": "ejy", "obj_id": "irw"}
+{"sub_label": "a green apple", "obj_label": "the kid", "sub_id": "sgq", "obj_id": "irw"}
+{"sub_label": "a leaf", "obj_label": "the caterpillar", "sub_id": "jpl", "obj_id": "zte"}
+{"sub_label": "a plant", "obj_label": "the caterpillar", "sub_id": "pmz", "obj_id": "zte"} 

--- a/tests/test_data/dummy_dataset_multiple_templates/metadata_relations.json
+++ b/tests/test_data/dummy_dataset_multiple_templates/metadata_relations.json
@@ -1,0 +1,17 @@
+{
+  "example_1": {
+    "name": "lost",
+    "templates": [
+      "[X] lost [Y].",
+      "[Y] was lost by [X]."
+    ]
+  },
+  "example_2": {
+    "name": "eaten by",
+    "templates": [
+      "[Y] eats [X].",
+      "[Y] consumes [X].",
+      "[X] is often eaten by [Y]."
+    ]
+  }
+}

--- a/tests/test_template_indices.py
+++ b/tests/test_template_indices.py
@@ -1,0 +1,66 @@
+import logging
+
+import numpy as np
+
+from lm_pub_quiz import Dataset, DatasetResults, Evaluator
+
+log = logging.getLogger(__name__)
+
+
+def test_single_template_index(request, distilbert):
+    model, tokenizer = distilbert
+    evaluator = Evaluator.from_model(model, tokenizer=tokenizer)
+
+    dataset = Dataset.from_path(
+        request.path.parent / "test_data" / "dummy_dataset_multiple_templates",
+    )
+
+    results = evaluator.evaluate_dataset(
+        dataset,
+        template_index=0,
+    )
+
+    df = results.joined_instance_table()
+    df["predicted_answer_idx"] = df["pll_scores"].apply(np.argmax)
+
+    assert df["template_idx"].unique() == [0]
+
+    assert (df["predicted_answer_idx"] == [0, 1, 2, 0, 0, 1, 1, 2, 2]).all()
+
+
+def test_list_of_templates(request, distilbert):
+    model, tokenizer = distilbert
+    evaluator = Evaluator.from_model(model, tokenizer=tokenizer)
+
+    dataset = Dataset.from_path(
+        request.path.parent / "test_data" / "dummy_dataset_multiple_templates",
+    )
+
+    results = evaluator.evaluate_dataset(
+        dataset,
+        template_index=[0, 1],
+    )
+
+    df = results.joined_instance_table()
+
+    assert df["template_idx"].unique() == [0, 1]
+
+
+def test_all_templates(request, distilbert, tmp_path):
+    model, tokenizer = distilbert
+    evaluator = Evaluator.from_model(model, tokenizer=tokenizer)
+
+    dataset = Dataset.from_path(
+        request.path.parent / "test_data" / "dummy_dataset_multiple_templates",
+    )
+
+    results = evaluator.evaluate_dataset(
+        dataset,
+        template_index=None,
+        save_path=tmp_path,
+    )
+
+    results = DatasetResults.from_path(tmp_path)
+    df = results.joined_instance_table()
+
+    assert df["template_idx"].unique() == [0, 1, 2]

--- a/tests/test_template_indices.py
+++ b/tests/test_template_indices.py
@@ -21,11 +21,11 @@ def test_single_template_index(request, distilbert):
     )
 
     df = results.joined_instance_table()
-    df["predicted_answer_idx"] = df["pll_scores"].apply(np.argmax)
+    df["predicted_answer_index"] = df["pll_scores"].apply(np.argmax)
 
-    assert df["template_idx"].unique() == [0]
+    assert (df["template_index"].unique() == [0]).all()
 
-    assert (df["predicted_answer_idx"] == [0, 1, 2, 0, 0, 1, 1, 2, 2]).all()
+    assert (df["predicted_answer_index"] == [0, 1, 2, 0, 0, 1, 1, 2, 2]).all()
 
 
 def test_list_of_templates(request, distilbert):
@@ -43,7 +43,7 @@ def test_list_of_templates(request, distilbert):
 
     df = results.joined_instance_table()
 
-    assert df["template_idx"].unique() == [0, 1]
+    assert (df["template_index"].unique() == [0, 1]).all()
 
 
 def test_all_templates(request, distilbert, tmp_path):
@@ -63,4 +63,6 @@ def test_all_templates(request, distilbert, tmp_path):
     results = DatasetResults.from_path(tmp_path)
     df = results.joined_instance_table()
 
-    assert df["template_idx"].unique() == [0, 1, 2]
+    assert (df["template_index"].unique() == [0, 1, 2]).all()
+
+    assert len(df) == 2 * 3 + 3 * 6


### PR DESCRIPTION
With this PR, `template_indices` can be se to either:
- an integer (specifying the template index; if a relation does not have as many templates, it is skipped),
- a list of integers, or 
- None (which leads to all templates being used).

Using multiple templates leads to longer instance tables (one entry per template).